### PR TITLE
Configure secure session cookies

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -3,3 +3,17 @@
 define('SESSION_TTL', 1800);
 // Pfad zur Session-Datenbank
 define('SESSION_DB', __DIR__ . '/../sessions.sqlite');
+
+// Cookie settings for sessions
+if (!defined('SESSION_COOKIE_LIFETIME')) {
+    define('SESSION_COOKIE_LIFETIME', 0); // Session cookie
+}
+if (!defined('SESSION_COOKIE_SECURE')) {
+    define('SESSION_COOKIE_SECURE', true);
+}
+if (!defined('SESSION_COOKIE_HTTPONLY')) {
+    define('SESSION_COOKIE_HTTPONLY', true);
+}
+if (!defined('SESSION_COOKIE_SAMESITE')) {
+    define('SESSION_COOKIE_SAMESITE', 'Strict');
+}

--- a/index.php
+++ b/index.php
@@ -5,6 +5,12 @@ require_once __DIR__ . '/includes/functions.php';
 
 $handler = new DbSessionHandler(SESSION_DB, SESSION_TTL);
 session_set_save_handler($handler, true);
+session_set_cookie_params([
+    'lifetime' => SESSION_COOKIE_LIFETIME,
+    'secure' => SESSION_COOKIE_SECURE,
+    'httponly' => SESSION_COOKIE_HTTPONLY,
+    'samesite' => SESSION_COOKIE_SAMESITE,
+]);
 session_start();
 
 if (isset($_POST['logout'])) {

--- a/login.php
+++ b/login.php
@@ -5,6 +5,12 @@ require_once __DIR__ . '/includes/functions.php';
 
 $handler = new DbSessionHandler(SESSION_DB, SESSION_TTL);
 session_set_save_handler($handler, true);
+session_set_cookie_params([
+    'lifetime' => SESSION_COOKIE_LIFETIME,
+    'secure' => SESSION_COOKIE_SECURE,
+    'httponly' => SESSION_COOKIE_HTTPONLY,
+    'samesite' => SESSION_COOKIE_SAMESITE,
+]);
 session_start();
 
 $login_error = '';


### PR DESCRIPTION
## Summary
- centralize cookie settings in `includes/config.php`
- configure session cookie options before starting the session in `login.php`
- apply the same secure cookie settings in `index.php`

## Testing
- `curl -I http://localhost:8000/test_session.php` (shows session cookie with `Secure; HttpOnly; SameSite=Strict`)


------
https://chatgpt.com/codex/tasks/task_b_687a9c7eaaf0832886686bc10c4dda66